### PR TITLE
Launch MainActivity on QS_TILE_PREFERENCES

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,9 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES"/>
+            </intent-filter>
         </activity>
 
         <activity android:name=".ui.TextActivity" />


### PR DESCRIPTION
Android will launch the application detail settings when user long click the quick settings tiles by default.

We can add action [`android.service.quicksettings.action.QS_TILE_PREFERENCES`](https://developer.android.com/reference/android/service/quicksettings/TileService.html#ACTION_QS_TILE_PREFERENCES) to the intent-filter of MainActivity in manifest and let users go into MainActivity, which makes this action more meaningful. 

I also found some problem may cause the build failure. If you prefer to use that, see [`haruue:patch-fix-build-problem-and-qstile`](https://github.com/V2Ray-Android/Actinium/compare/master...haruue:patch-fix-build-problem-and-qstile). 